### PR TITLE
fix: Resolve PostCSS ES modules configuration

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
-  },
+  }
 }


### PR DESCRIPTION
## Description
Fixed PostCSS configuration to properly work with ES modules setup.

## Changes
- Converted postcss.config.js from CommonJS to ES modules syntax
- Verified Tailwind CSS now loads correctly

## Impact
Resolves Vite server error:
`Failed to load PostCSS config (searchPath: ...): [ReferenceError] module is not defined in ES module scope`